### PR TITLE
Correct default number of slices to match help info.

### DIFF
--- a/tools/mcurl.sh
+++ b/tools/mcurl.sh
@@ -20,7 +20,7 @@
 # v0.1        initial version
 # v0.1.1      add output option
 
-slices=$(grep -c processor /proc/cpuinfo)
+slices=20
 url=
 output=
 


### PR DESCRIPTION
Help info claims that the default number of slices is 20, however this was not the case.
Replacing the `$(grep -c processor /proc/cpuinfo)` with the fixed number `20` simplifies the script and makes it more portable (I am adding MacOS support which has no `/proc/cpuinfo`)