### PR TITLE
mcurl : fix du command to work on MacOS.

### DIFF
--- a/tools/mcurl.sh
+++ b/tools/mcurl.sh
@@ -132,7 +132,7 @@ done
 until [ $is_finished -eq 1 ]
 do
 	if [ -f $$.1 ];then
-		total_kb=$(du -b $$.* | awk '{t+=$1}END{printf "%d", t/1024}')
+		total_kb=$(BLOCKSIZE=1024 du -k $$.* | awk '{t+=$1}END{printf "%d", t}')
 		duration=$((`date +%s`-$start_time))
 		[ $duration -gt 0 ] && printf "\rCurrent average speed %4d KiB/s" $(($total_kb/$duration))
 	fi


### PR DESCRIPTION
`du -b` is non-standard on BSD / MacOS.
Switching to `du -k` and then _not_ dividing by 1024 so that the command works on MacOS as well as Linux.
Also set `BLOCKSIZE=1024` to be sure that the POSIX `512` isn't used.